### PR TITLE
fix: make URL validation case-insensitive for domains

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -15,9 +15,9 @@
 - [ ] #61: meta: dead code removal summary and verification
 
 ## DOING (Current Work)
-- [x] #65: bug: URL validation is case-sensitive, should accept uppercase domains (branch: bug-65-case-insensitive-urls)
 
 ## DONE (Completed)
+- [x] #65: bug: URL validation is case-sensitive, should accept uppercase domains (PR #68)
 - [x] #64: bug: fetch command doesn't validate output filename before API calls (resolved by PR #67)
 - [x] #63: bug: file permission check happens after expensive API calls (branch: bug-63-file-permission-check-timing)
 - [x] #62: bug: uncaught exception in Scholar source with empty search results (branch: bug-62-scholar-empty-results)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,6 @@
 # Development Backlog
 
 ## TODO (Ordered by Priority)
-- [ ] #65: bug: URL validation is case-sensitive, should accept uppercase domains
 - [ ] #50: dead: remove legacy `fetch_publications` method
 - [ ] #53: dead: remove unused private methods in sources module
 - [ ] #52: dead: remove duplicate fuzzy matching implementations
@@ -16,6 +15,7 @@
 - [ ] #61: meta: dead code removal summary and verification
 
 ## DOING (Current Work)
+- [x] #65: bug: URL validation is case-sensitive, should accept uppercase domains (branch: bug-65-case-insensitive-urls)
 
 ## DONE (Completed)
 - [x] #64: bug: fetch command doesn't validate output filename before API calls (resolved by PR #67)

--- a/puby/cli.py
+++ b/puby/cli.py
@@ -98,7 +98,7 @@ def _initialize_sources(
     sources: List[PublicationSource] = []
 
     if scholar:
-        if "scholar.google.com" not in scholar:
+        if "scholar.google.com" not in scholar.lower():
             click.echo(f"Error: Invalid Scholar URL: {scholar}", err=True)
             sys.exit(1)
         try:
@@ -108,7 +108,7 @@ def _initialize_sources(
             sys.exit(1)
 
     if orcid:
-        if "orcid.org" not in orcid:
+        if "orcid.org" not in orcid.lower():
             click.echo(f"Error: Invalid ORCID URL: {orcid}", err=True)
             sys.exit(1)
         try:
@@ -118,7 +118,7 @@ def _initialize_sources(
             sys.exit(1)
 
     if pure:
-        if not pure.startswith("https://"):
+        if not pure.lower().startswith("https://"):
             click.echo(f"Error: Pure URL must use HTTPS: {pure}", err=True)
             sys.exit(1)
         try:
@@ -498,7 +498,7 @@ def fetch(orcid: Optional[str], output: str) -> None:
     client = PublicationClient()
     
     # URL validation consistent with check command
-    if "orcid.org" not in orcid:
+    if "orcid.org" not in orcid.lower():
         click.echo(f"Error: Invalid ORCID URL: {orcid}", err=True)
         sys.exit(1)
     


### PR DESCRIPTION
## Summary

- Fixes URL validation to be case-insensitive for domain names per RFC standards
- URLs with uppercase domains (HTTPS://ORCID.ORG, HTTPS://SCHOLAR.GOOGLE.COM) now work correctly
- Comprehensive test coverage for all URL validation scenarios

## Changes Made

- **CLI URL validation**: Convert URLs to lowercase before domain checks
- **ORCID URLs**: Support uppercase domains in both `check` and `fetch` commands
- **Scholar URLs**: Accept uppercase `SCHOLAR.GOOGLE.COM` domains  
- **Pure URLs**: Support uppercase `HTTPS://` protocol and domains
- **Test Coverage**: Added `TestCLICaseInsensitiveURLValidation` class with 6 comprehensive tests

## Test Plan

✅ Uppercase ORCID URL: `HTTPS://ORCID.ORG/0000-0003-4773-416X`  
✅ Mixed case ORCID URL: `https://ORCID.org/0000-0003-4773-416X`  
✅ Uppercase Scholar URL: `HTTPS://SCHOLAR.GOOGLE.COM/citations?user=test`  
✅ Uppercase Pure URL: `HTTPS://research.example.edu/person/john-doe`  
✅ Fetch command with uppercase ORCID URL  
✅ All existing functionality preserved  

Fixes #65