### PR TITLE
dead: remove unused ORCIDConfig class from models

### DIFF
--- a/puby/models.py
+++ b/puby/models.py
@@ -456,27 +456,6 @@ class ZoteroConfig:
         return all(c.isascii() and c.isalnum() for c in api_key)
 
 
-@dataclass
-class ORCIDConfig:
-    """Configuration for ORCID API access."""
-
-    orcid_id: str
-
-    def is_valid(self) -> bool:
-        """Check if configuration is valid."""
-        return len(self.validation_errors()) == 0
-
-    def validation_errors(self) -> List[str]:
-        """Get list of validation errors."""
-        errors = []
-
-        if not self.orcid_id or not self.orcid_id.strip():
-            errors.append("ORCID ID is required")
-        elif not _is_valid_orcid(self.orcid_id):
-            errors.append("ORCID ID must follow format 0000-0000-0000-0000")
-
-        return errors
-
 
 def _is_valid_orcid(orcid: str) -> bool:
     """Validate ORCID ID format."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 """Tests for publication models."""
 
-from puby.models import Author, ORCIDConfig, Publication, ZoteroConfig
+from puby.models import Author, Publication, ZoteroConfig
 
 
 class TestAuthor:
@@ -401,34 +401,6 @@ class TestZoteroConfig:
         errors = config.validation_errors()
         assert "Group ID is required for group library type" in errors
 
-
-class TestORCIDConfig:
-    """Test ORCID configuration model."""
-
-    def test_orcid_config_creation(self):
-        """Test creating ORCID configuration."""
-        config = ORCIDConfig(orcid_id="0000-0000-0000-0000")
-        assert config.orcid_id == "0000-0000-0000-0000"
-
-    def test_orcid_config_validation_valid(self):
-        """Test valid ORCID configuration validation."""
-        config = ORCIDConfig(orcid_id="0000-0000-0000-0000")
-        assert config.is_valid()
-        assert len(config.validation_errors()) == 0
-
-    def test_orcid_config_validation_invalid_format(self):
-        """Test invalid ORCID format validation."""
-        config = ORCIDConfig(orcid_id="invalid-id")
-        assert not config.is_valid()
-        errors = config.validation_errors()
-        assert "ORCID ID must follow format 0000-0000-0000-0000" in errors
-
-    def test_orcid_config_validation_empty(self):
-        """Test empty ORCID validation."""
-        config = ORCIDConfig(orcid_id="")
-        assert not config.is_valid()
-        errors = config.validation_errors()
-        assert "ORCID ID is required" in errors
 
 
 class TestPublicationValidation:


### PR DESCRIPTION
## Summary
- Removes `ORCIDConfig` class from `puby/models.py` that was defined but never used in production code
- Removes corresponding `TestORCIDConfig` test class 
- Keeps `_is_valid_orcid()` function as it's still used by `Author` class validation
- Eliminates 20 lines of dead code and 27 lines of dead tests

## Evidence of Non-Use
- `ORCIDConfig` only appears in models.py definition and test_models.py
- `ORCIDSource` in orcid_source.py doesn't use `ORCIDConfig` 
- CLI directly initializes `ORCIDSource` with URL string, not `ORCIDConfig`
- No production code creates or uses `ORCIDConfig` instances

## Benefits
- **Cleaner API**: Removes unused public interface
- **Reduced Complexity**: Less code to maintain and understand
- **Consistency**: Matches actual usage patterns in production code

## Files Changed
- **Modified**: `puby/models.py` - Removed ORCIDConfig class (lines 459-478)
- **Modified**: `tests/test_models.py` - Removed TestORCIDConfig test class

## Test Results
✅ All model tests pass - no functionality loss
✅ Preserved _is_valid_orcid function for Author class validation
✅ Zero regression risk as class was unused in production

Fixes #57