### PR TITLE
fix: clarify fetch command documentation and improve error message

### DIFF
--- a/puby/cli.py
+++ b/puby/cli.py
@@ -477,10 +477,10 @@ def check(
     default="publications.bib",
 )
 def fetch(orcid: Optional[str], output: str) -> None:
-    """Fetch publications from a source and save to file."""
+    """Fetch publications from ORCID and save to BibTeX file."""
 
     if not orcid:
-        click.echo("Error: --orcid is required for fetch command", err=True)
+        click.echo("Error: --orcid is required", err=True)
         sys.exit(1)
 
     # Validate output file writeability before making any API calls


### PR DESCRIPTION
## Summary
- Updates fetch command docstring from misleading 'Fetch publications from a source' to accurate 'Fetch publications from ORCID and save to BibTeX file'
- Simplifies error message from '--orcid is required for fetch command' to '--orcid is required'
- Resolves inconsistency where documentation suggested multi-source support but only ORCID is implemented

## Problem
The fetch command's docstring said 'Fetch publications from a source and save to file' (generic) but only implements ORCID support, creating confusion about its capabilities versus the check command which does support multiple sources.

## Solution
Updated documentation to accurately reflect current functionality rather than expanding scope, following the principle of honest API documentation.

## Files Changed
- **Modified**: `puby/cli.py` - Updated fetch command docstring and error message

## Benefits
- **Accurate Documentation**: Users have clear expectations about fetch command capabilities  
- **Consistent Messaging**: Error message is more concise and consistent with CLI patterns
- **Reduced Confusion**: No longer misleads users about multi-source support

## Test Results
✅ All CLI tests pass with improved documentation
✅ fetch command behavior unchanged - only documentation clarity improved
✅ Error messages are more user-friendly

Fixes #59